### PR TITLE
Fixing test folder browsing

### DIFF
--- a/zunit
+++ b/zunit
@@ -568,7 +568,7 @@ function _zunit_parse_argument() {
   # If the argument is a directory
   if [[ -d $argument ]]; then
     # Loop through each of the files in the directory
-    for file in $(find $argument -depth 1); do
+    for file in $(find $argument -type f); do
       # Run it through the parser again
       _zunit_parse_argument $file
     done


### PR DESCRIPTION
When running with no argument (or a directory name), `zunit` fails with : 
```shell
find: unrecognized: 1
```

In [`find` man page](http://man7.org/linux/man-pages/man1/find.1.html), the following can be read about `-depth` option (which takes no parameter): 

> Process each directory's contents before the directory itself.

Which is actually not what is desired. The expected behaviour of `zunit` seems to be browsing each unit test folder recursively. To avoid infinite recursion, I propose to select only files using the `find` built-in option `-type`.