### PR TITLE
Add init command to bootstrap new projects

### DIFF
--- a/zunit
+++ b/zunit
@@ -664,6 +664,15 @@ directories:
   output: tests/_output
   support: tests/_support"
 
+  local example="#!/usr/bin/env zunit
+
+@test 'Example' {
+  run echo 1
+
+  assert "'"$state"'" equals 1
+  assert "'"$output"'" same_as "'"incorrect"'"
+}"
+
   if [[ -f "$PWD/.zunit.yml" ]]; then
     echo $(color red 'Zunit config file already exists at $PWD/.zunit.yml') >&2
     exit 1
@@ -677,6 +686,8 @@ directories:
   else
     mkdir -p tests/_{output,support}
     touch tests/_{output,support}/.gitkeep
+
+    echo "$example" > "$PWD/tests/example.zunit"
   fi
 }
 

--- a/zunit
+++ b/zunit
@@ -331,7 +331,11 @@ function assert() {
 ###
 function _zunit_usage() {
   echo "$(color yellow 'Usage:')"
-  echo "  zunit [options] <tests...>"
+  echo "  zunit [options] [command] [tests...]"
+  echo
+  echo "$(color yellow 'Commands:')"
+  echo "  init               Bootstrap zunit in a new project"
+  echo "  run [tests...]        Run tests"
   echo
   echo "$(color yellow 'Options:')"
   echo "  -h, --help         Output help text and exit"
@@ -653,11 +657,45 @@ _zunit_parse_yaml() {
   }' | sed 's/_=/+=/g'
 }
 
+function _zunit_init() {
+  local yaml="tap: false
+directories:
+  tests: tests
+  output: tests/_output
+  support: tests/_support"
+
+  if [[ -f "$PWD/.zunit.yml" ]]; then
+    echo $(color red 'Zunit config file already exists at $PWD/.zunit.yml') >&2
+    exit 1
+  else
+    echo "$yaml" > "$PWD/.zunit.yml"
+  fi
+
+  if [[ -d "$PWD/tests" ]]; then
+    echo $(color red 'Directory already exists at $PWD/tests') >&2
+    exit 1
+  else
+    mkdir -p tests/_{output,support}
+    touch tests/_{output,support}/.gitkeep
+  fi
+}
+
 ###
 # Run tests
 ###
 function _zunit_run() {
   local -a arguments testfiles
+
+  zparseopts -D -E \
+    h=help -help=help \
+    v=version -version=version \
+    f=fail_fast -fail-fast=fail_fast \
+    t=tap -tap=tap
+
+  if [[ -n $tap ]] || [[ "$zunit_config_tap" = "true" ]]; then
+    tap=1
+  fi
+
   arguments=("$@")
   testfiles=()
 
@@ -727,11 +765,9 @@ function _zunit() {
 
   [[ $missing_dependencies -gt 0 ]] && exit 1
 
-  zparseopts -D \
+  zparseopts -D -E \
     h=help -help=help \
-    v=version -version=version \
-    f=fail_fast -fail-fast=fail_fast \
-    t=tap -tap=tap
+    v=version -version=version
 
   # If the help option is passed,
   # output usage information and exit
@@ -747,11 +783,17 @@ function _zunit() {
     exit 0
   fi
 
-  if [[ -n $tap ]] || [[ "$zunit_config_tap" = "true" ]]; then
-    tap=1
-  fi
-
-  _zunit_run "$@"
+  case "$ctx" in
+    init )
+      _zunit_init "${(@)@:2}"
+      ;;
+    run )
+      _zunit_run "${(@)@:2}"
+      ;;
+    * )
+      _zunit_run "$@"
+      ;;
+  esac
 }
 
 _zunit "$@"

--- a/zunit
+++ b/zunit
@@ -335,13 +335,39 @@ function _zunit_usage() {
   echo
   echo "$(color yellow 'Commands:')"
   echo "  init               Bootstrap zunit in a new project"
-  echo "  run [tests...]        Run tests"
+  echo "  run [tests...]     Run tests"
   echo
   echo "$(color yellow 'Options:')"
   echo "  -h, --help         Output help text and exit"
   echo "  -v, --version      Output version information and exit"
   echo "  -f, --fail-fast    Stop the test runner immediately after the first failure"
   echo "  -t, --tap          Output results in a TAP compatible format"
+}
+
+###
+# Output usage information and exit
+###
+function _zunit_run_usage() {
+  echo "$(color yellow 'Usage:')"
+  echo "  zunit run [options] [tests...]"
+  echo
+  echo "$(color yellow 'Options:')"
+  echo "  -h, --help         Output help text and exit"
+  echo "  -v, --version      Output version information and exit"
+  echo "  -f, --fail-fast    Stop the test runner immediately after the first failure"
+  echo "  -t, --tap          Output results in a TAP compatible format"
+}
+
+###
+# Output usage information and exit
+###
+function _zunit_init_usage() {
+  echo "$(color yellow 'Usage:')"
+  echo "  zunit init [options]"
+  echo
+  echo "$(color yellow 'Options:')"
+  echo "  -h, --help         Output help text and exit"
+  echo "  -v, --version      Output version information and exit"
 }
 
 ###
@@ -780,13 +806,6 @@ function _zunit() {
     h=help -help=help \
     v=version -version=version
 
-  # If the help option is passed,
-  # output usage information and exit
-  if [[ -n $help ]]; then
-    _zunit_usage
-    exit 0
-  fi
-
   # If the version option is passed,
   # output version information and exit
   if [[ -n $version ]]; then
@@ -796,12 +815,33 @@ function _zunit() {
 
   case "$ctx" in
     init )
+      # If the help option is passed,
+      # output usage information and exit
+      if [[ -n $help ]]; then
+        _zunit_init_usage
+        exit 0
+      fi
+
       _zunit_init "${(@)@:2}"
       ;;
     run )
+      # If the help option is passed,
+      # output usage information and exit
+      if [[ -n $help ]]; then
+        _zunit_run_usage
+        exit 0
+      fi
+
       _zunit_run "${(@)@:2}"
       ;;
     * )
+      # If the help option is passed,
+      # output usage information and exit
+      if [[ -n $help ]]; then
+        _zunit_usage
+        exit 0
+      fi
+
       _zunit_run "$@"
       ;;
   esac

--- a/zunit.zsh-completion
+++ b/zunit.zsh-completion
@@ -1,5 +1,10 @@
 #compdef zunit
 
+_zunit_commands=(
+  'run:Run tests'
+  'init:Bootstrap ZUnit in a new project'
+)
+
 _zunit() {
   typeset -A opt_args
   local context state line curcontext="$curcontext"
@@ -11,7 +16,34 @@ _zunit() {
     '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]'
 
   _arguments \
-    '*:test:_files'
+    '1: :_zunit_cmds' \
+    '*::arg:->args'
+
+  case "$state" in
+    args )
+      case "$words[1]" in
+        init )
+          _arguments -A \
+            '(-h --help)'{-h,--help}'[show help text and exit]' \
+            '(-v --version)'{-v,--version}'[show version information and exit]'
+          ;;
+        run )
+          _arguments -A \
+            '(-h --help)'{-h,--help}'[show help text and exit]' \
+            '(-v --version)'{-v,--version}'[show version information and exit]' \
+            '(-f --fail-fast)'{-f,--fail-fast}'[stop execution after the first failure]' \
+            '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]'
+
+          _arguments \
+            '*:tests:_files'
+          ;;
+      esac
+      ;;
+  esac
+}
+
+(( $+functions[_zunit_cmds] )) || _zunit_cmds() {
+  _describe -t commands 'commands' _zunit_commands "$@"
 }
 
 _zunit "$@"


### PR DESCRIPTION
Also moves the test runner behind a `run` command, which is the default