### PR TITLE
Source bootstrap script

### DIFF
--- a/zunit
+++ b/zunit
@@ -937,6 +937,20 @@ function _zunit_run() {
     echo 'TAP version 13' >! $logfile_text
   fi
 
+  if [[ -n $zunit_config_directories_support ]]; then
+    local support="$zunit_config_directories_support"
+    if [[ ! -d $support ]]; then
+      echo $(color red "Support directory at $support is missing")
+      exit 1
+    fi
+
+    if [[ -f "$support/bootstrap" ]]; then
+      source "$support/bootstrap"
+      echo "$(color green '✔') Sourced bootstrap script $support/bootstrap"
+      which crash
+    fi
+  fi
+
   arguments=("$@")
   testfiles=()
 

--- a/zunit
+++ b/zunit
@@ -896,6 +896,10 @@ directories:
     mkdir -p tests/_{output,support}
     touch tests/_{output,support}/.gitkeep
 
+    echo '#!/usr/bin/env zsh
+
+# Write your bootstrap code here' > tests/_support/bootstrap
+
     echo "$example" > "$PWD/tests/example.zunit"
   fi
 }


### PR DESCRIPTION
* Runs a script at `tests/_support/bootstrap` prior to running tests, if it exists.
* Creates an empty bootstrap script when running `zunit init`

Fix #21 