### PR TITLE
Show results on exit when `--fail-fast` is specified

### DIFF
--- a/zunit
+++ b/zunit
@@ -398,6 +398,11 @@ function _zunit_fail_shutdown() {
   # Kill the revolver process
   [[ -z $tap ]] && revolver stop
 
+  echo $(color red bold 'Execution halted after failure')
+  end_time=$((EPOCHREALTIME*1000))
+
+  [[ -z $tap ]] && _zunit_output_results
+
   exit 1
 }
 


### PR DESCRIPTION
Fix #27