### PR TITLE
Output version information before running tests

### DIFF
--- a/zunit
+++ b/zunit
@@ -1114,7 +1114,7 @@ function _zunit_run() {
 
   # Print version information
   echo $(color yellow 'Launching ZUnit')
-  echo "ZUnit: $(zunit --version)"
+  echo "ZUnit: $(_zunit_version)"
   echo "ZSH:   $(zsh --version)"
   echo
 
@@ -1211,6 +1211,13 @@ function _zunit_run() {
 }
 
 ###
+# Output the version number
+###
+function _zunit_version() {
+  echo '0.5.0'
+}
+
+###
 # The main zunit process
 ###
 function _zunit() {
@@ -1252,7 +1259,7 @@ function _zunit() {
   # If the version option is passed,
   # output version information and exit
   if [[ -n $version ]]; then
-    echo '0.5.0'
+    _zunit_version
     exit 0
   fi
 

--- a/zunit
+++ b/zunit
@@ -1112,6 +1112,12 @@ function _zunit_run() {
   local fail_fast tap allow_risky
   local output_text logfile_text output_html logfile_html
 
+  # Print version information
+  echo $(color yellow 'Launching ZUnit')
+  echo "ZUnit: $(zunit --version)"
+  echo "ZSH:   $(zsh --version)"
+  echo
+
   zmodload zsh/datetime
   local start_time=$((EPOCHREALTIME*1000)) end_time
 


### PR DESCRIPTION
Useful for CI environments using [zvm](https://github.com/molovo/zvm) or similiar for testing multiple versions, to ensure the correct versions are being sourced at runtime.