### PR TITLE
v0.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ before_script:
 - curl -L https://raw.githubusercontent.com/molovo/revolver/master/revolver > .bin/revolver
 - curl -L https://raw.githubusercontent.com/molovo/color/master/color.zsh > .bin/color
 - curl -L https://raw.githubusercontent.com/molovo/zvm/master/zvm > .bin/zvm
-- curl -L https://raw.githubusercontent.com/molovo/zvm/master/zvm-shell-integration.zsh
-  > zvm-shell-integration.zsh
+- curl -L https://raw.githubusercontent.com/molovo/zvm/master/zvm-shell-integration.zsh > zvm-shell-integration.zsh
 - chmod u+x .bin/{color,revolver,zvm}
 - export PATH="$HOME/.zvm/bin:$PWD/.bin:$PATH"
 - zvm use ${ZVM_VERSION}

--- a/src/commands/init.zsh
+++ b/src/commands/init.zsh
@@ -62,19 +62,19 @@ directories:
 # Write your bootstrap code here"
 
   # An example .travis.yml config
-  local travis_yml='addons:
+  local travis_yml="addons:
   apt:
     packages:
       zsh
 install:
   - mkdir .bin
-  - curl -L https://github.com/molovo/zunit/releases/download/v0.6.2/zunit > .bin/zunit
+  - curl -L https://github.com/molovo/zunit/releases/download/v$(_zunit_version)/zunit > .bin/zunit
   - curl -L https://raw.githubusercontent.com/molovo/revolver/master/revolver > .bin/revolver
   - curl -L https://raw.githubusercontent.com/molovo/color/master/color.zsh > .bin/color
 before_script:
   - chmod u+x .bin/{color,revolver,zunit}
-  - export PATH="$PWD/.bin:$PATH"
-script: zunit'
+  - export PATH=\"\$PWD/.bin:\$PATH\"
+script: zunit"
 
   # Check that a config file doesn't already exist so that
   # we don't overwrite it

--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -113,11 +113,11 @@ function _zunit_execute_test() {
       [[ \$_zunit_assertion_count -gt 0 ]] || return 248
     }"
 
-    # Quietly eval the body into a variable as a first test
-    output=$(eval "$(echo "$func")" 2>&1)
-
     # Increment the test count
     total=$(( total + 1 ))
+
+    # Quietly eval the body into a variable as a first test
+    output=$(eval "$(echo "$func")" 2>&1)
 
     # Check the status of the eval, and output any errors
     if [[ $? -ne 0 ]]; then

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -29,7 +29,7 @@ function _zunit_usage() {
 # Output the version number
 ###
 function _zunit_version() {
-  echo '0.6.3'
+  echo '0.6.4'
 }
 
 ###


### PR DESCRIPTION
### Bugfixes

* [x] Fixes a bug where the wrong exit code was read after parsing a test body, meaning some parsing errors may not have been caught.
* [x] Ensures the ZUnit version currently being used is printed into the generated `.travis.yml` when running `zunit init --travis`

---

* [x] Bump version