### PR TITLE
v0.7.0

### DIFF
--- a/.zunit.yml
+++ b/.zunit.yml
@@ -4,3 +4,4 @@ directories:
   output: tests/_output
   support: tests/_support
 time_limit: 15
+fail_fast: true

--- a/.zunit.yml
+++ b/.zunit.yml
@@ -5,3 +5,4 @@ directories:
   support: tests/_support
 time_limit: 15
 fail_fast: true
+allow_risky: false

--- a/src/commands/init.zsh
+++ b/src/commands/init.zsh
@@ -47,7 +47,10 @@ function _zunit_init() {
 directories:
   tests: tests
   output: tests/_output
-  support: tests/_support"
+  support: tests/_support
+time_limit: 0
+fail_fast: false
+allow_risky: false"
 
   # An example test file
   local example="#!/usr/bin/env zunit

--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -513,6 +513,11 @@ function _zunit_run() {
     fail_fast=1
   fi
 
+  # Check if allow_risky is specified in the config or as an option
+  if [[ -z $allow_risky ]] && [[ "$zunit_config_allow_risky" = "true" ]]; then
+    allow_risky=1
+  fi
+
   arguments=("$@")
   testfiles=()
 

--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -508,6 +508,11 @@ function _zunit_run() {
     fi
   fi
 
+  # Check if fail_fast is specified in the config or as an option
+  if [[ -z $fail_fast ]] && [[ "$zunit_config_fail_fast" = "true" ]]; then
+    fail_fast=1
+  fi
+
   arguments=("$@")
   testfiles=()
 

--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -10,13 +10,14 @@ function _zunit_run_usage() {
   echo "  zunit run [options] [tests...]"
   echo
   echo "$(color yellow 'Options:')"
-  echo "  -h, --help         Output help text and exit"
-  echo "  -v, --version      Output version information and exit"
-  echo "  -f, --fail-fast    Stop the test runner immediately after the first failure"
-  echo "  -t, --tap          Output results in a TAP compatible format"
-  echo "      --output-text  Print results to a text log, in TAP compatible format"
-  echo "      --output-html  Print results to a HTML page"
-  echo "      --allow-risky  Supress warnings generated for risky tests"
+  echo "  -h, --help             Output help text and exit"
+  echo "  -v, --version          Output version information and exit"
+  echo "  -f, --fail-fast        Stop the test runner immediately after the first failure"
+  echo "  -t, --tap              Output results in a TAP compatible format"
+  echo "      --output-text      Print results to a text log, in TAP compatible format"
+  echo "      --output-html      Print results to a HTML page"
+  echo "      --allow-risky      Supress warnings generated for risky tests"
+  echo "      --time-limit <n>   Set a time limit of n seconds for each test"
 }
 
 ###
@@ -142,16 +143,16 @@ function _zunit_execute_test() {
     # the ZSH version is at least 5.1.0, since older versions of ZSH
     # are unable to handle asynchronous processes in the way we need
     autoload is-at-least
-    if is-at-least 5.1.0 && [[ -n $zunit_config_time_limit ]]; then
+    if is-at-least 5.1.0 && [[ -n ${time_limit:#0} ]]; then
       # Create another wrapper function around the test
       __zunit_async_test_wrapper() {
         local pid
 
-        # Get the current timestamp, and the time limit, and use those to
-        # work out the kill time for the sub process
-        integer time_limit=$(( ${zunit_config_time_limit:-30} * 1000 ))
+        # Get the current timestamp, and the time limit in ms, and use
+        # those to work out the kill time for the sub process
+        integer time_limit_ms=$(( time_limit * 1000 ))
         integer time=$(( EPOCHREALTIME * 1000 ))
-        integer kill_time=$(( $time + $time_limit ))
+        integer kill_time=$(( $time + $time_limit_ms ))
 
         # Launch the test function asynchronously and store its PID
         __zunit_tmp_test_function &
@@ -189,7 +190,7 @@ function _zunit_execute_test() {
 
       return
     elif [[ $state -eq 78 ]]; then
-      _zunit_error "Test took too long to run. Terminated after ${zunit_config_time_limit:-30} seconds" $output
+      _zunit_error "Test took too long to run. Terminated after $time_limit seconds" $output
 
       return
     elif [[ -z $allow_risky && $state -eq 248 ]]; then
@@ -439,7 +440,8 @@ function _zunit_run() {
     t=tap -tap=tap \
     -output-text=output_text \
     -output-html=output_html \
-    -allow-risky=allow_risky
+    -allow-risky=allow_risky \
+    -time-limit:=time_limit
 
   # TAP output is enabled
   if [[ -n $tap ]] || [[ "$zunit_config_tap" = "true" ]]; then
@@ -506,6 +508,13 @@ function _zunit_run() {
       source "$support/bootstrap"
       echo "$(color green '✔') Sourced bootstrap script $support/bootstrap"
     fi
+  fi
+
+  # Check if time_limit is specified in the config or as an option
+  if [[ -n $time_limit ]]; then
+    shift time_limit
+  elif [[ -n $zunit_config_time_limit ]]; then
+    time_limit=$zunit_config_time_limit
   fi
 
   arguments=("$@")

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -29,7 +29,7 @@ function _zunit_usage() {
 # Output the version number
 ###
 function _zunit_version() {
-  echo '0.6.4'
+  echo '0.7.0'
 }
 
 ###

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -23,6 +23,7 @@ function _zunit_usage() {
   echo "      --output-text  Print results to a text log, in TAP compatible format"
   echo "      --output-html  Print results to a HTML page"
   echo "      --allow-risky  Supress warnings generated for risky tests"
+  echo "      --time-limit   Set a time limit in seconds for each test"
 }
 
 ###

--- a/zunit.zsh-completion
+++ b/zunit.zsh-completion
@@ -9,18 +9,22 @@ _zunit() {
   typeset -A opt_args
   local context state line curcontext="$curcontext"
 
+  _arguments \
+    '1: :_zunit_cmds' \
+    '*::arg:->args'
+
+  _arguments \
+    '*:tests:_files'
+
   _arguments -A \
     '(-h --help)'{-h,--help}'[show help text and exit]' \
     '(-v --version)'{-v,--version}'[show version information and exit]' \
     '(-f --fail-fast)'{-f,--fail-fast}'[stop execution after the first failure]' \
     '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]' \
-    '--output-text[Print results to a text log, in TAP compatible format]' \
-    '--output-html[Print results to a HTML page]' \
-    '--allow-risky[Supress warnings generated for risky tests]'
-
-  _arguments \
-    '1: :_zunit_cmds' \
-    '*::arg:->args'
+    '--output-text[print results to a text log, in TAP compatible format]' \
+    '--output-html[print results to a HTML page]' \
+    '--allow-risky[supress warnings generated for risky tests]' \
+    '--time-limit[set a time limit in seconds for each test]'
 
   case "$state" in
     args )
@@ -28,17 +32,20 @@ _zunit() {
         init )
           _arguments -A \
             '(-h --help)'{-h,--help}'[show help text and exit]' \
-            '(-v --version)'{-v,--version}'[show version information and exit]'
+            '(-t --travis)'{-t,--travis}'[generate a .travis.yml file]'
+
+          _arguments \
+            '*::arg:->args'
           ;;
         run )
           _arguments -A \
             '(-h --help)'{-h,--help}'[show help text and exit]' \
-            '(-v --version)'{-v,--version}'[show version information and exit]' \
             '(-f --fail-fast)'{-f,--fail-fast}'[stop execution after the first failure]' \
             '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]' \
-            '--output-text[Print results to a text log, in TAP compatible format]' \
-            '--output-html[Print results to a HTML page]' \
-            '--allow-risky[Supress warnings generated for risky tests]'
+            '--output-text[print results to a text log, in TAP compatible format]' \
+            '--output-html[print results to a HTML page]' \
+            '--allow-risky[supress warnings generated for risky tests]' \
+            '--time-limit[set a time limit in seconds for each test]'
 
           _arguments \
             '*:tests:_files'


### PR DESCRIPTION
### Features

- [x] Adds `--time-limit` CLI option, to override `time_limit` setting in `.zunit.yml`. (#57)
- [x] Adds `allow_risky` setting in `.zunit.yml`, which is overridden by `--allow-risky` option. (#55)
- [x] Adds `fail_fast` setting in `.zunit.yml`, which is overridden by `--fail-fast` option. (#55)

Possible:

- [ ] Allow tests to expect [crash](https://github.com/molovo/crash) exceptions. (#51)

### Bugfixes

- [x] Fix completion script

---

- [x] Update Documentation (molovo/zunit-www#1)
- [x] Bump Version