### PR TITLE
Allow fail_fast and allow_risky to be set in .zunit.yml

### DIFF
--- a/.zunit.yml
+++ b/.zunit.yml
@@ -4,3 +4,4 @@ directories:
   output: tests/_output
   support: tests/_support
 time_limit: 15
+fail_fast: true

--- a/.zunit.yml
+++ b/.zunit.yml
@@ -5,3 +5,4 @@ directories:
   support: tests/_support
 time_limit: 15
 fail_fast: true
+allow_risky: false

--- a/src/commands/init.zsh
+++ b/src/commands/init.zsh
@@ -47,7 +47,10 @@ function _zunit_init() {
 directories:
   tests: tests
   output: tests/_output
-  support: tests/_support"
+  support: tests/_support
+time_limit: 0
+fail_fast: false
+allow_risky: false"
 
   # An example test file
   local example="#!/usr/bin/env zunit

--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -513,6 +513,11 @@ function _zunit_run() {
     fail_fast=1
   fi
 
+  # Check if allow_risky is specified in the config or as an option
+  if [[ -z $allow_risky ]] && [[ "$zunit_config_allow_risky" = "true" ]]; then
+    allow_risky=1
+  fi
+
   arguments=("$@")
   testfiles=()
 

--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -508,6 +508,11 @@ function _zunit_run() {
     fi
   fi
 
+  # Check if fail_fast is specified in the config or as an option
+  if [[ -z $fail_fast ]] && [[ "$zunit_config_fail_fast" = "true" ]]; then
+    fail_fast=1
+  fi
+
   arguments=("$@")
   testfiles=()
 

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -29,7 +29,7 @@ function _zunit_usage() {
 # Output the version number
 ###
 function _zunit_version() {
-  echo '0.6.4'
+  echo '0.7.0'
 }
 
 ###


### PR DESCRIPTION
Fix #55