### PR TITLE
Add --verbose option

### DIFF
--- a/.zunit.yml
+++ b/.zunit.yml
@@ -6,3 +6,4 @@ directories:
 time_limit: 15
 fail_fast: true
 allow_risky: false
+verbose: false

--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -14,6 +14,7 @@ function _zunit_run_usage() {
   echo "  -v, --version          Output version information and exit"
   echo "  -f, --fail-fast        Stop the test runner immediately after the first failure"
   echo "  -t, --tap              Output results in a TAP compatible format"
+  echo "      --verbose          Prints full output from each test"
   echo "      --output-text      Print results to a text log, in TAP compatible format"
   echo "      --output-html      Print results to a HTML page"
   echo "      --allow-risky      Supress warnings generated for risky tests"
@@ -194,10 +195,16 @@ function _zunit_execute_test() {
 
       return
     elif [[ -z $allow_risky && $state -eq 248 ]]; then
+      # If --verbose is specified, print test output to screen
+      [[ -n $verbose && -n $output ]] && echo $output
+
       _zunit_warn 'No assertions were run, test is risky'
 
       return
     elif [[ -n $allow_risky && $state -eq 248 ]] || [[ $state -eq 0 ]]; then
+      # If --verbose is specified, print test output to screen
+      [[ -n $verbose && -n $output ]] && echo $output
+
       _zunit_success
 
       return
@@ -426,7 +433,7 @@ function _zunit_parse_argument() {
 ###
 function _zunit_run() {
   local -a arguments testfiles
-  local fail_fast tap allow_risky
+  local fail_fast tap allow_risky verbose
   local output_text logfile_text output_html logfile_html
 
   # Load the datetime module, and record the start time
@@ -438,6 +445,7 @@ function _zunit_run() {
     v=version -version=version \
     f=fail_fast -fail-fast=fail_fast \
     t=tap -tap=tap \
+    -verbose=verbose \
     -output-text=output_text \
     -output-html=output_html \
     -allow-risky=allow_risky \
@@ -518,6 +526,11 @@ function _zunit_run() {
   # Check if allow_risky is specified in the config or as an option
   if [[ -z $allow_risky ]] && [[ "$zunit_config_allow_risky" = "true" ]]; then
     allow_risky=1
+  fi
+
+  # Check if verbose is specified in the config or as an option
+  if [[ -z $verbose ]] && [[ "$zunit_config_verbose" = "true" ]]; then
+    verbose=1
   fi
 
   # Check if time_limit is specified in the config or as an option

--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -75,6 +75,11 @@ function run() {
   # Restore $IFS
   IFS=$oldIFS
 
+  # Print the command output if --verbose is specified
+  if [[ -n $verbose && -n $output ]]; then
+    echo $output
+  fi
+
   # Restore the exit on error state
   setopt ERR_EXIT
 }

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -20,6 +20,7 @@ function _zunit_usage() {
   echo "  -v, --version      Output version information and exit"
   echo "  -f, --fail-fast    Stop the test runner immediately after the first failure"
   echo "  -t, --tap          Output results in a TAP compatible format"
+  echo "      --verbose      Prints full output from each test"
   echo "      --output-text  Print results to a text log, in TAP compatible format"
   echo "      --output-html  Print results to a HTML page"
   echo "      --allow-risky  Supress warnings generated for risky tests"

--- a/zunit.zsh-completion
+++ b/zunit.zsh-completion
@@ -21,6 +21,7 @@ _zunit() {
     '(-v --version)'{-v,--version}'[show version information and exit]' \
     '(-f --fail-fast)'{-f,--fail-fast}'[stop execution after the first failure]' \
     '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]' \
+    '--verbose[prints full output from each test]' \
     '--output-text[print results to a text log, in TAP compatible format]' \
     '--output-html[print results to a HTML page]' \
     '--allow-risky[supress warnings generated for risky tests]' \
@@ -42,6 +43,7 @@ _zunit() {
             '(-h --help)'{-h,--help}'[show help text and exit]' \
             '(-f --fail-fast)'{-f,--fail-fast}'[stop execution after the first failure]' \
             '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]' \
+            '--verbose[prints full output from each test]' \
             '--output-text[print results to a text log, in TAP compatible format]' \
             '--output-html[print results to a HTML page]' \
             '--allow-risky[supress warnings generated for risky tests]' \


### PR DESCRIPTION
Prints the full command output for each test, as well as any processes
launched using the `run` helper.

Also includes a `verbose` option in `.zunit.yml`

Fix #63 