### PR TITLE
Allow optional space in shebang

### DIFF
--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -409,7 +409,7 @@ function _zunit_parse_argument() {
     line=$(cat $argument | head -n 1)
 
     # Check for the zunit shebang
-    if [[ $line = "#!/usr/bin/env zunit" ]]; then
+    if [[ $line =~ "#! ?/usr/bin/env zunit" ]]; then
       # Add it to the array
       testfiles[(( ${#testfiles} + 1 ))]=("$argument${test_name+"@$test_name"}")
       return

--- a/tests/assertions/exists.zunit
+++ b/tests/assertions/exists.zunit
@@ -1,4 +1,4 @@
-#!/usr/bin/env zunit
+#! /usr/bin/env zunit
 
 @test 'Test _zunit_assert_exists success' {
   run assert './exists.zunit' exists


### PR DESCRIPTION
Really minor, but I often find that I type shebangs with a space between the `#!` and the path. For this reason I thought it would be nice to make the space optional.

I've updated a single test file with the new shebang pattern to show that it works, but I am not convinced this is the best way to test this.