### PR TITLE
v0.8.2

### DIFF
--- a/src/commands/init.zsh
+++ b/src/commands/init.zsh
@@ -82,19 +82,19 @@ script: zunit"
   # Check that a config file doesn't already exist so that
   # we don't overwrite it
   if [[ -f "$PWD/.zunit.yml" ]]; then
-    echo $(color red "Zunit config file already exists at $PWD/.zunit.yml") >&2
-    exit 1
+    echo $(color yellow "ZUnit config file already exists at $PWD/.zunit.yml. Skipping...")
   else
     # Write the contents to the config file
+    echo "Writing ZUnit config file to $PWD/.zunit.yml"
     echo "$yaml" > "$PWD/.zunit.yml"
   fi
 
   # Check that the tests directory doesn't already exist so that
   # we don't overwrite it
   if [[ -d "$PWD/tests" ]]; then
-    echo $(color red "Directory already exists at $PWD/tests") >&2
-    exit 1
+    echo $(color yellow "Test directory already exists at $PWD/tests. Skipping...")
   else
+    echo "Creating test directory at $PWD/tests"
     # Create the directory structure for tests
     mkdir -p tests/_{output,support}
     touch tests/_{output,support}/.gitkeep
@@ -109,9 +109,9 @@ script: zunit"
     # Check that a travis config doesn't already exist so that
     # we don't overwrite it
     if [[ -f "$PWD/.travis.yml" ]]; then
-      echo $(color red "Travis config already exists at $PWD/.travis.yml") >&2
-      exit 1
+      echo $(color yellow "Travis config already exists at $PWD/.travis.yml. Skipping...")
     else
+      echo "Writing Travis CI config to $PWD/.travis.yml"
       # Write the contents to the config file
       echo "$travis_yml" > "$PWD/.travis.yml"
     fi

--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -144,7 +144,7 @@ function assert() {
   _zunit_assertion_count=$(( _zunit_assertion_count + 1 ))
 
   # Run the assertion
-  "_zunit_assert_${assertion}" $value ${(@f)comparisons[@]}
+  "_zunit_assert_${assertion}" "$value" ${(@f)comparisons[@]}
 
   local state=$?
 

--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -81,7 +81,7 @@ function run() {
 
   # Store each word of the command in an array, and grab the first
   # argument which is the command name
-  cmd=(${@[@]})
+  cmd=("${@[@]}")
   name="${cmd[1]}"
 
   # If the command is not an existing command or file,

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -31,7 +31,7 @@ function _zunit_usage() {
 # Output the version number
 ###
 function _zunit_version() {
-  echo '0.9.0'
+  echo '0.8.2'
 }
 
 ###

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -31,7 +31,7 @@ function _zunit_usage() {
 # Output the version number
 ###
 function _zunit_version() {
-  echo '0.8.1'
+  echo '0.9.0'
 }
 
 ###

--- a/tests/assertions/contains.zunit
+++ b/tests/assertions/contains.zunit
@@ -34,3 +34,10 @@
   assert "$output" same_as "'elephants' does not contain 'foo'"
   assert $state equals 1
 }
+
+@test 'Test _zunit_assert_contains match failure with empty value' {
+  run assert '' contains 'foo'
+
+  assert "$output" same_as "'' does not contain 'foo'"
+  assert $state equals 1
+}

--- a/tests/assertions/different_to.zunit
+++ b/tests/assertions/different_to.zunit
@@ -11,3 +11,9 @@
   assert $state equals 1
   assert $output same_as "'test' is the same as 'test'"
 }
+
+@test 'Test _zunit_assert_different_to passes with empty value' {
+  run assert '' different_to 'test'
+  assert $state equals 0
+  assert $output is_empty
+}

--- a/tests/assertions/does_not_contain.zunit
+++ b/tests/assertions/does_not_contain.zunit
@@ -7,6 +7,13 @@
     assert $state equals 0
 }
 
+@test 'Test _zunit_assert_does_not_contain success with empty value' {
+    run assert '' does_not_contain 'foo'
+
+    assert "$output" is_empty
+    assert $state equals 0
+}
+
 @test 'Test _zunit_assert_does_not_contain failure' {
     run assert 'foobar' does_not_contain 'foo'
 

--- a/tests/assertions/does_not_match.zunit
+++ b/tests/assertions/does_not_match.zunit
@@ -10,6 +10,12 @@
   assert $output is_empty
 }
 
+@test 'Test _zunit_assert_does_not_match success with empty value' {
+  run assert '' does_not_match '[0-9]+'
+  assert $state equals 0
+  assert $output is_empty
+}
+
 @test 'Test _zunit_assert_does_not_match failure' {
   run assert 'test' does_not_match '[a-z]{4}'
   assert $state equals 1

--- a/tests/assertions/equals.zunit
+++ b/tests/assertions/equals.zunit
@@ -11,3 +11,9 @@
   assert $state equals 1
   assert $output same_as "'1' is not equal to '0'"
 }
+
+@test 'Test _zunit_assert_equals failure with empty value' {
+  run assert '' equals 1
+  assert $state equals 1
+  assert $output same_as "'' is not equal to '1'"
+}

--- a/tests/assertions/in.zunit
+++ b/tests/assertions/in.zunit
@@ -11,3 +11,9 @@
   assert $state equals 1
   assert "$output" same_as "'a' is not in (x y z)"
 }
+
+@test 'Test _zunit_assert_in failure with empty value' {
+  run assert '' in 'x' 'y' 'z'
+  assert $state equals 1
+  assert "$output" same_as "'' is not in (x y z)"
+}

--- a/tests/assertions/is_greater_than.zunit
+++ b/tests/assertions/is_greater_than.zunit
@@ -11,3 +11,9 @@
   assert $state equals 1
   assert $output same_as "'-1' is not greater than '1'"
 }
+
+@test 'Test _zunit_assert_is_greater_than failure with empty value' {
+  run assert '' is_greater_than 1
+  assert $state equals 1
+  assert $output same_as "'' is not greater than '1'"
+}

--- a/tests/assertions/is_key_in.zunit
+++ b/tests/assertions/is_key_in.zunit
@@ -21,3 +21,14 @@
   assert $state equals 1
   assert "$output" same_as "'a' is not a key in (x 1 y 2 z 3)"
 }
+
+@test 'Test _zunit_assert_is_key_in failure with empty value' {
+  typeset -A hash; hash=(
+    'x' 1
+    'y' 2
+    'z' 3
+  )
+  run assert '' is_key_in ${(@kv)hash}
+  assert $state equals 1
+  assert "$output" same_as "'' is not a key in (x 1 y 2 z 3)"
+}

--- a/tests/assertions/is_less_than.zunit
+++ b/tests/assertions/is_less_than.zunit
@@ -11,3 +11,9 @@
   assert $state equals 1
   assert $output same_as "'2' is not less than '1'"
 }
+
+@test 'Test _zunit_assert_is_less_than failure' {
+  run assert '' is_less_than -1
+  assert $state equals 1
+  assert $output same_as "'' is not less than '-1'"
+}

--- a/tests/assertions/is_negative.zunit
+++ b/tests/assertions/is_negative.zunit
@@ -11,3 +11,9 @@
   assert $state equals 1
   assert $output same_as "'1' is not negative"
 }
+
+@test 'Test _zunit_assert_is_negative failure with empty value' {
+  run assert '' is_negative
+  assert $state equals 1
+  assert $output same_as "'' is not negative"
+}

--- a/tests/assertions/is_not_key_in.zunit
+++ b/tests/assertions/is_not_key_in.zunit
@@ -11,6 +11,17 @@
   assert "$output" is_empty
 }
 
+@test 'Test _zunit_assert_is_not_key_in success with empty value' {
+  typeset -A assoc; assoc=(
+    'x' 1
+    'y' 2
+    'z' 3
+  )
+  run assert '' is_not_key_in ${(@kv)assoc}
+  assert $state equals 0
+  assert "$output" is_empty
+}
+
 @test 'Test _zunit_assert_is_not_key_in failure' {
   typeset -A assoc; assoc=(
     'a' 1

--- a/tests/assertions/is_not_substring_of.zunit
+++ b/tests/assertions/is_not_substring_of.zunit
@@ -13,3 +13,10 @@
     assert "$output" same_as "'foo' is a substring of 'foobar'"
     assert $state equals 1
 }
+
+@test 'Test _zunit_assert_is_substring_of failure with empty value' {
+    run assert '' is_not_substring_of 'foobar'
+
+    assert "$output" same_as "'' is a substring of 'foobar'"
+    assert $state equals 1
+}

--- a/tests/assertions/is_not_value_in.zunit
+++ b/tests/assertions/is_not_value_in.zunit
@@ -11,6 +11,17 @@
   assert "$output" is_empty
 }
 
+@test 'Test _zunit_assert_is_not_value_in success with empty value' {
+  typeset -A hash; hash=(
+    'x' 7
+    'y' 8
+    'z' 9
+  )
+  run assert '' is_not_value_in ${(@kv)hash}
+  assert $state equals 0
+  assert "$output" is_empty
+}
+
 @test 'Test _zunit_assert_is_not_value_in failure' {
   typeset -A hash; hash=(
     'a' 1

--- a/tests/assertions/is_positive.zunit
+++ b/tests/assertions/is_positive.zunit
@@ -11,3 +11,9 @@
   assert $state equals 1
   assert $output same_as "'-1' is not positive"
 }
+
+@test 'Test _zunit_assert_is_positive failure with empty value' {
+  run assert '' is_positive
+  assert $state equals 1
+  assert $output same_as "'' is not positive"
+}

--- a/tests/assertions/is_substring_of.zunit
+++ b/tests/assertions/is_substring_of.zunit
@@ -7,6 +7,13 @@
   assert $state equals 0
 }
 
+@test 'Test _zunit_assert_is_substring_of match with empty value' {
+  run assert '' is_substring_of 'hello world'
+
+  assert "$output" is_empty
+  assert $state equals 0
+}
+
 @test 'Test _zunit_assert_is_substring_of suffix match' {
   run assert 'world' is_substring_of 'hello world'
 

--- a/tests/assertions/is_value_in.zunit
+++ b/tests/assertions/is_value_in.zunit
@@ -21,3 +21,14 @@
   assert $state equals 1
   assert "$output" same_as "'4' is not a value in (x 1 y 2 z 3)"
 }
+
+@test 'Test _zunit_assert_is_value_in failure with empty value' {
+  typeset -A hash; hash=(
+    'x' 1
+    'y' 2
+    'z' 3
+  )
+  run assert '' is_value_in ${(@kv)hash}
+  assert $state equals 1
+  assert "$output" same_as "'' is not a value in (x 1 y 2 z 3)"
+}

--- a/tests/assertions/matches.zunit
+++ b/tests/assertions/matches.zunit
@@ -19,3 +19,9 @@
   assert $state equals 1
   assert $output same_as "'123' does not match /[a-z]+/"
 }
+
+@test 'Test _zunit_assert_matches failure with empty value' {
+  run assert '' matches '[a-z]+'
+  assert $state equals 1
+  assert $output same_as "'' does not match /[a-z]+/"
+}

--- a/tests/assertions/not_equal_to.zunit
+++ b/tests/assertions/not_equal_to.zunit
@@ -6,6 +6,18 @@
   assert $output is_empty
 }
 
+@test 'Test _zunit_assert_not_equal_to success with empty value' {
+  run assert '' not_equal_to 1
+  assert $state equals 0
+  assert $output is_empty
+}
+
+@test 'Test _zunit_assert_not_equal_to success with empty comparison' {
+  run assert 1 not_equal_to ''
+  assert $state equals 0
+  assert $output is_empty
+}
+
 @test 'Test _zunit_assert_not_equal_to failure' {
   run assert 1 not_equal_to 1
   assert $state equals 1

--- a/tests/assertions/not_in.zunit
+++ b/tests/assertions/not_in.zunit
@@ -6,6 +6,12 @@
   assert $output is_empty
 }
 
+@test 'Test _zunit_assert_not_in success with empty value' {
+  run assert '' not_in 'x' 'y' 'z'
+  assert $state equals 0
+  assert $output is_empty
+}
+
 @test 'Test _zunit_assert_not_in failure' {
   run assert 'a' not_in 'a' 'b' 'c'
   assert $state equals 1

--- a/tests/assertions/same_as.zunit
+++ b/tests/assertions/same_as.zunit
@@ -11,3 +11,9 @@
   assert $state equals 1
   assert $output same_as "'test' is not the same as 'wrong'"
 }
+
+@test 'Test _zunit_assert_same_as failure with empty value' {
+  run assert '' same_as 'wrong'
+  assert $state equals 1
+  assert $output same_as "'' is not the same as 'wrong'"
+}


### PR DESCRIPTION
## Enhancements

* [x] The `zunit init` command now skips files which already exist and prints a warning, rather than exiting with an error. (#89)

## Bugfixes

* [x] Prevents false-positives from occurring when empty values are passed into some assertion functions. (#90)

## Todo

* [x] Update Documentation
* [x] Bump Version