### PR TITLE
Introduce assert_not function

### DIFF
--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -113,10 +113,7 @@ function run() {
   setopt ERR_EXIT
 }
 
-###
-# Redirect the assertion shorthand to the correct function
-###
-function assert() {
+function _assert() {
   local value=$1 assertion=$2
   local -a comparisons
 
@@ -148,15 +145,38 @@ function assert() {
 
   local state=$?
 
-  # If the assertion failed, then return that exit code to the
-  # test, which will stop its execution and mark it as failed
+  # Reset $IFS
+   IFS=$oldIFS
+
+   return $state
+}
+
+
+###
+# Redirect the assertion shorthand to the correct function
+###
+function assert() {
+  _assert "$@"
+  local state=$?
+
   if [[ $state -ne 0 ]]; then
     exit $state
   fi
-
-  # Reset $IFS
-  IFS=$oldIFS
 }
+
+
+###
+# Redirect the assertion shorthand to the correct function
+###
+function assert_not() {
+  _assert "$@"
+  local state=$?
+
+  if [[ $state -eq 0 ]]; then
+    exit $state
+  fi
+}
+
 
 ###
 # Mark the current test as passed

--- a/tests/assertions/in.zunit
+++ b/tests/assertions/in.zunit
@@ -1,5 +1,10 @@
 #!/usr/bin/env zunit
 
+@test 'Test not _zunit_assert_in success' {
+  run assert_not 'a' in 'b' 'c'
+  assert "$output" same_as "'a' is not in (b c)"
+}
+
 @test 'Test _zunit_assert_in success' {
   run assert 'a' in 'a' 'b' 'c'
   assert $state equals 0


### PR DESCRIPTION
This is a very early implementation of an idea I had a few weeks back. Opened this early to get some feedback before continuing 

Introduce an `assert_not` function that behaves the exact same way that `assert` does but with a negated result.

This should prevent the need to stay adding negative functions for every assertion created "same_as" / "different_to" etc. It also reads quite nicely imo:

```
assert_not "hello world" same_as "not the same thing"
```

Opening this PR early to get some early feedback about the approach