### PR TITLE
run.zsh – don't depend on external tools (tr,sed), use Zsh code instead

### DIFF
--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -221,13 +221,20 @@ function _zunit_execute_test() {
 # Encode test name into a value which can be used as a hash key
 ###
 function _zunit_encode_test_name() {
-  echo "$1" | tr A-Z a-z \
-            | tr _ ' ' \
-            | tr - ' ' \
-            | tr -s ' ' \
-            | sed 's/\- /-/' \
-            | sed 's/ \-/-/' \
-            | tr ' ' "-"
+  setopt localoptions extendedglob noshwordsplit noksharrays
+  local -A map
+  map=(
+    "_" ' '
+    "-" ' '
+  )
+
+  1=${1//(#b)([A-Z])/${(L)match[1]}}                  # tr A-Z a-z
+  1=${1//(#b)(?)/${map[${match[1]}]:-${match[1]}}}    # tr _ ' ' | tr - ' '
+  1=${1//[[:space:]]##/ }                             # tr -s ' ', but also with unicode, also vertical spaces
+  1=${${1//- /-}// -/-}                               # sed 's/\- /-/' | sed 's/ \-/-/'
+  1=${1// /-}                                         # tr ' ' "-"
+
+  print -r -- "$1"
 }
 
 ###


### PR DESCRIPTION
Tested this with:

```zsh
for word in "${(@z)"$(<zsh-tag-search)"}"; do
    res1="$(_zunit_encode_test_name $word)"
    res2="$(_zunit_encode_test_name_new $word)"
    [[ "$res1" != "$res2" ]] && print -r -- Different for $word
done
```

It behaves the same, with two exceptions:
- `echo "$1"` for `$1 == -n` or `$1 == -e` was yielding empty output because `echo` thought it's an option for it,
- `[[:space:]]` includes vertical spaces, tests show that `tr -s ' '` doesn't; it also includes unicode spaces, unsure if `tr -s ' '` did.

I'm doing this PR for Hacktoberfest, I hope you find it useful (this is needed by the Hactoberfest's rules).
