### PR TITLE
WIP: Add option to prevent capture of stderr in tests

### DIFF
--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -445,7 +445,7 @@ function _zunit_run() {
   local -a arguments testfiles
   local fail_fast tap allow_risky verbose
   local output_text logfile_text output_html logfile_html
-  local no_capture_err=0
+  local no_capture_err
 
   # Load the datetime module, and record the start time
   zmodload zsh/datetime

--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -92,7 +92,11 @@ function run() {
   fi
 
   # Store full output in a variable
-  output=$("${cmd[@]}" 2>&1)
+  if [[ $no_capture_err -eq 1 ]]; then
+    output=$("${cmd[@]}")
+  else
+    output=$("${cmd[@]}" 2>&1)
+  fi
 
   # Get the process exit state
   state="$?"

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -16,15 +16,16 @@ function _zunit_usage() {
   echo "  run [tests...]     Run tests"
   echo
   echo "$(color yellow 'Options:')"
-  echo "  -h, --help         Output help text and exit"
-  echo "  -v, --version      Output version information and exit"
-  echo "  -f, --fail-fast    Stop the test runner immediately after the first failure"
-  echo "  -t, --tap          Output results in a TAP compatible format"
-  echo "      --verbose      Prints full output from each test"
-  echo "      --output-text  Print results to a text log, in TAP compatible format"
-  echo "      --output-html  Print results to a HTML page"
-  echo "      --allow-risky  Supress warnings generated for risky tests"
-  echo "      --time-limit   Set a time limit in seconds for each test"
+  echo "  -h, --help             Output help text and exit"
+  echo "  -v, --version          Output version information and exit"
+  echo "  -f, --fail-fast        Stop the test runner immediately after the first failure"
+  echo "  -E, --no-capture-err   Don't capture stderr in tests"
+  echo "  -t, --tap              Output results in a TAP compatible format"
+  echo "      --verbose          Prints full output from each test"
+  echo "      --output-text      Print results to a text log, in TAP compatible format"
+  echo "      --output-html      Print results to a HTML page"
+  echo "      --allow-risky      Supress warnings generated for risky tests"
+  echo "      --time-limit <n>   Set a time limit of n seconds for each test"
 }
 
 ###

--- a/tests/fixtures/standard-error.zsh
+++ b/tests/fixtures/standard-error.zsh
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+echo "Standard Output"
+echo "Standard Error" >&2

--- a/tests/fixtures/standard-error.zunit
+++ b/tests/fixtures/standard-error.zunit
@@ -1,0 +1,8 @@
+#!/usr/bin/env zunit
+
+@test 'Run standard-error.zsh' { 
+  run tests/fixtures/standard-error.zsh
+
+  assert $state equals 0
+  assert "$output" same_as 'Standard Output'
+}

--- a/tests/options.zunit
+++ b/tests/options.zunit
@@ -1,0 +1,7 @@
+#!/usr/bin/env zunit
+
+@test 'Test option to prevent capture of stderr' {
+  run tests/fixtures/standard-error.zunit
+
+  assert "$output" does_not_contain 'Standard Error'
+}


### PR DESCRIPTION
This PR adds an option `-E`, or `--no-capture-err` to prevent capturing stderr in tests.

The main purpose of this PR, at the time of opening, is to allow another tool, [cover](https://github.com/shellm-org/cover), to compute coverage while running a test suite through ZUnit.

Cover needs the standard error, on which the xtrace output of Zsh is written, to see what lines were executed or not.

Todo:
- add tests