### PR TITLE
helpers.zsh: A new helper `evl' <-> eval of the supplied code

### DIFF
--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -144,7 +144,7 @@ function evl() {
   # Store full output in a variable
 
   local -a ___dont_quote
-  ___dont_quote=( ";" "[[:digit:]]>&[[:digit:]]" )
+  ___dont_quote=( ";" "[[:digit:]]>&[[:digit:]]" "\\|" "\\|\\|" "&" "&&" )
 
   # Prepare the output file
   local ___OUTFILE=$(mktemp)


### PR DESCRIPTION
Hello,
the commit provides a new helper – **evl** – an acronym of `eval`. It resembles `run` in any possible way except for one thing – it runs the provided code **within current shell**, through `eval`. This allows to test various additional side effects of the tested code and sometimes allows to write a shorter and simpler code, like here: [fast-syntax-highlighting/main.zunit](https://github.com/zdharma/fast-syntax-highlighting/blob/master/tests/main.zunit), compared to the `run`-version: [fast-syntax-highlighting/example.zunit](https://github.com/zdharma/fast-syntax-highlighting/blob/master/tests/example.zunit)