### PR TITLE
Allow to run complex commands

### DIFF
--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -200,3 +200,5 @@ function skip() {
   echo "$@"
   exit 48
 }
+
+# vim:ft=zsh:et:sts=2:sw=2

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env zsh
 
+setopt extendedglob typesetsilent
+
 ######################
 # Main zunit process #
 ######################


### PR DESCRIPTION
Basically, instead of:
```zsh
     output=$("${cmd[@]}" 2>&1)
```

it is done:
```zsh
     eval "output=$( ${cmd[@]} 2>&1)"
```

because this allows the command to include e.g. redirections or command separators like ; or ||, etc., or pipes, etc.

Actually, the eval looks more terrifying:
```zsh
  IFS=$'\n' eval "output=\$( function run {
        ${cmd[@]/(#m)*/${${${${${(M)MATCH:#(${(j:|:)~dont_quote})}:+$MATCH}}:-\"$MATCH\"}}} 2>&1 }; run )";
```

But the substitution is (as always..) simple: it quotes the command's arguments by using double quotes, so that when eval sees it, it will not skip empty strings (and also that it will not split strings). The `dont_quote` array holds things that are not to be quoted – currently the semicolon and redirections (`'[[:digit:]]>&[[:digit:]]`). The `run` function is to make the error messages look the same, i.e.:

```
run:1: command not found: a-non-existent-command
```

instead of `(eval):1: command ...`. I've checked that zunit's tests pass normally with this change.

The change allowed to create the following test-case: https://github.com/zdharma/fast-syntax-highlighting/blob/master/tests/example.zunit