### PR TITLE
helpers.zsh: Change the special-constructs (like `>>') handling for eval

### DIFF
--- a/src/helpers.zsh
+++ b/src/helpers.zsh
@@ -103,6 +103,9 @@ function run() {
 
   # Remove quoting of the needed constructs like: >>
   cmd=( "${cmd[@]//(#m)(${(~j.|.)dont_quote})/${(Q)MATCH}}" )
+  
+  # Also remove one-level of the quoting from \$var, \{, etc.
+  ___cmd=( "${___cmd[@]//(#m)\\[$\{\}()@]/${(Q)MATCH}}" )
 
   # The new line is important, it makes the error messages include the line
   # number, i.e. e.g.:
@@ -170,6 +173,9 @@ function evl() {
 
   # Remove quoting of the needed constructs like: >>
   ___cmd=( "${___cmd[@]//(#m)(${(~j.|.)${(q)___dont_quote[@]}})/${(Q)MATCH}}" )
+
+  # Also remove one-level of the quoting from \$var, \{
+  ___cmd=( "${___cmd[@]//(#m)\\[$\{\}()@]/${(Q)MATCH}}" )
 
   # Prepare the output file
   local ___OUTFILE=$(mktemp)


### PR DESCRIPTION
Now there's no problem when the argument itself contains a double-quote, as it's automatically quoted by using the (q) flag. Before, when someone did e.g.:

```zsh
var='"hello" "world"`
run cmd "$var" !
```

Then the command that would have been executed would be:

```zsh
eval 'cmd ""hello" "world"" "!"`'
```

which was pretty meaningless thing to do ̧– to add the extra double-quotes around the argument. Now, the command that'll be run will be:

```zsh
eval 'cmd \"hello\"\ \"world\" \!'
```
And it'll work as expected – the eval will receive the arguments correctly separated.