### PR TITLE
Skip non-.zunit files when recursing on a test directory

### DIFF
--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -403,6 +403,11 @@ function _zunit_parse_argument() {
   if [[ -d $argument ]]; then
     # Loop through each of the files in the directory
     for file in $(find $argument -mindepth 1 -maxdepth 1); do
+      # Skip further processing for files without a .zunit extension
+      if [[ -f $file && $file != *.zunit ]]; then
+        continue
+      fi
+
       # Run it through the parser again
       _zunit_parse_argument $file
     done


### PR DESCRIPTION
I decided to implement this check inside the directory recursion instead of inside the file check. That way, someone can still call `zunit testfile.weirdextension` and have things work. The .zunit extension requirement is only in place when doing directory recursion.

fixes #114 