### PR TITLE
Fix an issue where `revolver stop` was not called when `$output_html` is empty

### DIFF
--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -581,7 +581,10 @@ function _zunit_run() {
   [[ -n $output_html ]] && _zunit_html_footer >> $logfile_html
 
   # Output results to screen and kill the progress indicator
-  [[ -z $tap ]] && _zunit_output_results && revolver stop
+  if [[ -z $tap ]]; then
+      _zunit_output_results
+      revolver stop
+  fi
 
   # If the total of ($passed + $skipped) is not equal to the
   # total, then there must have been failures, errors or warnings,


### PR DESCRIPTION
`revolver stop` in `_zunit_run` was not called because `_zunit_output_results` returns 1 when `$output_html` is empty.
