### PR TITLE
Ensure teardown is always executed

### DIFF
--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -82,8 +82,11 @@ function _zunit_execute_test() {
       # Add an exit handler which calls the teardown function if it is
       # defined and the test exits early
       if (( \$+functions[__zunit_test_teardown] )); then
-        zshexit() {
+        TRAPEXIT() {
           __zunit_test_teardown 2>&1
+        }
+        TRAPZERR() {
+          [[ -o ERR_EXIT ]] && __zunit_test_teardown 2>&1
         }
       fi
 
@@ -101,14 +104,6 @@ function _zunit_execute_test() {
       # The test body is printed here, so when we eval the wrapper
       # function it will be read as part of the body of this function
       ${body}
-
-      # If a teardown function is defined, run it now
-      if (( \$+functions[__zunit_test_teardown] )); then
-        __zunit_test_teardown 2>&1
-      fi
-
-      # Remove the error handler
-      zshexit() {}
 
       # Check the assertion count, and if it is 0, return
       # the warning exit code

--- a/tests/setup-and-teardown.zunit
+++ b/tests/setup-and-teardown.zunit
@@ -1,27 +1,50 @@
 #!/usr/bin/env zunit
 
 @setup {
-	SOME_VAR='rainbows'
+  SOME_VAR='rainbows'
 }
 
 @teardown {
-	unset SOME_VAR
+  unset SOME_VAR
+  unset SOME_VAR_TEARDOWN
 }
 
 @test 'Check value of SOME_VAR' {
-	assert $SOME_VAR same_as 'rainbows'
+  assert $SOME_VAR same_as 'rainbows'
 }
 
 @test 'Change value of SOME_VAR' {
-	SOME_VAR='unicorns'
-	assert $SOME_VAR same_as 'unicorns'
+  SOME_VAR='unicorns'
+  assert $SOME_VAR same_as 'unicorns'
 }
 
 @test 'Check value of SOME_VAR again' {
-	# Check will fail, because the variable was unset in
-	# the @teardown method, and then reset to 'rainbows'
-	# when @setup was run again.
-	run assert $SOME_VAR same_as 'unicorns'
+  # Check will fail, because the variable was unset in
+  # the @teardown method, and then reset to 'rainbows'
+  # when @setup was run again.
+  run assert $SOME_VAR same_as 'unicorns'
 
-	assert $state equals 1
+  assert $state equals 1
+}
+
+@test 'Change value of SOME_VAR_TEARDOWN' {
+  SOME_VAR_TEARDOWN='rainbows'
+  run true
+
+  assert $state equals 0
+}
+
+@test 'Check value of SOME_VAR_TEARDOWN' {
+  assert $SOME_VAR_TEARDOWN is_empty
+}
+
+@test 'Change value of SOME_VAR_TEARDOWN again' {
+  SOME_VAR_TEARDOWN='rainbows'
+  run false
+
+  assert $state equals 1
+}
+
+@test 'Check value of SOME_VAR_TEARDOWN again' {
+  assert $SOME_VAR_TEARDOWN is_empty
 }


### PR DESCRIPTION
In some cases especially when tests failed due to `err_exit`, the teardown function was not executed. This PR uses trap functions to ensure it is always executed.

```zsh
@setup {
  tempfile=test
  touch $tempfile
}

@teardown {
  # Here is not executed in some of the following cases
  rm $tempfile
}

@test 'case ok' {
  # This case is totally OK because `run` temporarily disables `err_exit` (using unsetopt)
  run false
}

@test 'case ng' {
  # This PR fixes this case where the test fails with `err_exit` being set
  false
}
```

I tried to show this by adding test cases that cover them which resulted in the entire test to break because it needs to be somehow failed...