### PR TITLE
feat: add "-q/--quiet" flag to supress revolver spinner

### DIFF
--- a/src/commands/run.zsh
+++ b/src/commands/run.zsh
@@ -14,6 +14,8 @@ function _zunit_run_usage() {
   echo "  -v, --version          Output version information and exit"
   echo "  -f, --fail-fast        Stop the test runner immediately after the first failure"
   echo "  -t, --tap              Output results in a TAP compatible format"
+  echo "  -t, --tap              Output results in a TAP compatible format"
+  echo "  -q, --quiet            Supress revolver spinner for tests"
   echo "      --verbose          Prints full output from each test"
   echo "      --output-text      Print results to a text log, in TAP compatible format"
   echo "      --output-html      Print results to a HTML page"
@@ -47,12 +49,12 @@ function _zunit_output_results() {
   echo
   echo "$total tests run in $(_zunit_human_time $elapsed)"
   echo
-  echo "$(color yellow underline 'Results')                        "
-  echo "$(color green '✔') Passed      $passed                    "
-  echo "$(color red '✘') Failed      $failed                      "
-  echo "$(color red '‼') Errors      $errors                      "
-  echo "$(color magenta '●') Skipped     $skipped                 "
-  echo "$(color yellow '‼') Warnings    $warnings                 "
+  echo "$(color yellow  underline 'Results')                        "
+  echo "$(color green   '✔') Passed:   $passed                    "
+  echo "$(color red     '✘') Failed:   $failed                      "
+  echo "$(color red     '‼') Errors:   $errors                      "
+  echo "$(color magenta '●') Skipped:  $skipped                 "
+  echo "$(color yellow  '‼') Warnings: $warnings                 "
   echo
 
   [[ -n $output_text ]] && echo "TAP report written at $PWD/$logfile_text"

--- a/src/events.zsh
+++ b/src/events.zsh
@@ -47,7 +47,7 @@ function _zunit_success() {
     return
   fi
 
-  echo "$(color green '✔') ${name}"
+  echo "$(color green 'PASS') ${name}"
 }
 
 ###
@@ -65,7 +65,7 @@ function _zunit_failure() {
   if [[ -n $tap ]]; then
     _zunit_tap_failure "$@"
   else
-    echo "$(color red '✘' ${name})"
+    echo "$(color red 'FAILURE' ${name})"
     echo "  $(color red underline ${message})"
     echo "  $(color red ${output})"
   fi
@@ -88,7 +88,7 @@ function _zunit_error() {
   if [[ -n $tap ]]; then
     _zunit_tap_error "$@"
   else
-    echo "$(color red '‼' ${name})"
+    echo "$(color red 'ERROR' ${name})"
     echo "  $(color red underline ${message})"
     echo "  $(color red ${output})"
   fi
@@ -113,7 +113,7 @@ function _zunit_warn() {
     return
   fi
 
-  echo "$(color yellow '‼') ${name}"
+  echo "$(color yellow 'WARNING') ${name}"
   echo "  $(color yellow underline ${message})"
 }
 

--- a/src/zunit.zsh
+++ b/src/zunit.zsh
@@ -22,6 +22,7 @@ function _zunit_usage() {
   echo "  -v, --version      Output version information and exit"
   echo "  -f, --fail-fast    Stop the test runner immediately after the first failure"
   echo "  -t, --tap          Output results in a TAP compatible format"
+  echo "  -q, --quiet        Supress revolver spinner for tests"
   echo "      --verbose      Prints full output from each test"
   echo "      --output-text  Print results to a text log, in TAP compatible format"
   echo "      --output-html  Print results to a HTML page"

--- a/zunit.zsh-completion
+++ b/zunit.zsh-completion
@@ -21,6 +21,7 @@ _zunit() {
     '(-v --version)'{-v,--version}'[show version information and exit]' \
     '(-f --fail-fast)'{-f,--fail-fast}'[stop execution after the first failure]' \
     '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]' \
+    '(-q --quiet)'{-q,--quiet}'[supress revolver spinner for tests]' \
     '--verbose[prints full output from each test]' \
     '--output-text[print results to a text log, in TAP compatible format]' \
     '--output-html[print results to a HTML page]' \
@@ -43,6 +44,7 @@ _zunit() {
             '(-h --help)'{-h,--help}'[show help text and exit]' \
             '(-f --fail-fast)'{-f,--fail-fast}'[stop execution after the first failure]' \
             '(-t --tap)'{-t,--tap}'[output results in a TAP compatible format]' \
+            '(-q --quiet)'{-q,--quiet}'[supress revolver spinner for tests]' \
             '--verbose[prints full output from each test]' \
             '--output-text[print results to a text log, in TAP compatible format]' \
             '--output-html[print results to a HTML page]' \


### PR DESCRIPTION
Currently, Zunint tests generate a lot of noise due to the revolver creating a new line for each spinner frame. 

This PR adds a flag (`-q`/`--quiet`) to suppress revolver to reduce noise and make it easier to grok test output.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>