### PR TITLE
Add assertion for matching golden files

### DIFF
--- a/src/assertions.zsh
+++ b/src/assertions.zsh
@@ -435,3 +435,29 @@ function _zunit_assert_is_executable() {
   echo "'$pathname' does not exist or is not executable"
   exit 1
 }
+
+###
+# Assert the file content matches golden file.
+###
+function _zunit_assert_is_golden_file() {
+  local pathname=$1 filepath goldenname=$2 goldenpath
+
+  # If filepath is relative, prepend the test directory
+  if [[ "${pathname:0:1}" != "/" ]]; then
+    filepath="$testdir/${pathname}"
+  else
+    filepath="$pathname"
+  fi
+  
+  # If goldenpath is relative, prepend the test directory
+  if [[ "${goldenname:0:1}" != "/" ]]; then
+    goldenpath="$testdir/${goldenname}"
+  else
+    goldenpath="$goldenname"
+  fi
+
+  cmp -s $filepath $goldenpath && return 0
+
+  echo "'$pathname' does not match golden file content at '$goldenname'"
+  exit 1
+}

--- a/tests/_support/sample-file
+++ b/tests/_support/sample-file
@@ -1,0 +1,1 @@
+This sample file has same content as golden file and vice versa.

--- a/tests/_support/sample-file-golden
+++ b/tests/_support/sample-file-golden
@@ -1,0 +1,1 @@
+This sample file has same content as golden file and vice versa.

--- a/tests/assertions/is_golden_file.zunit
+++ b/tests/assertions/is_golden_file.zunit
@@ -1,0 +1,13 @@
+#!/usr/bin/env zunit
+
+@test 'Test _zunit_assert_is_golden_file success' {
+  run assert '../_support/sample-file' is_golden_file '../_support/sample-file-golden'
+  assert $state equals 0
+  assert $output is_empty
+}
+
+@test 'Test _zunit_assert_is_golden_file failure' {
+  run assert './is_golden_file.zunit' is_golden_file '../_support/sample-file-golden'
+  assert $state equals 1
+  assert $output same_as "'./is_golden_file.zunit' does not match golden file content at '../_support/sample-file-golden'"
+}


### PR DESCRIPTION
We use golden files matching in our tests. Output of our commands are written to files and we need to compare the content to match a golden file.

(More info at https://ieftimov.com/posts/testing-in-go-golden-files/)

This adds new assertion `is_golden_file` to match existing file with a content of golden file.